### PR TITLE
fix(auth): resolve OIDC authentication flow issues

### DIFF
--- a/apps/api/src/controllers/auth.ts
+++ b/apps/api/src/controllers/auth.ts
@@ -637,10 +637,12 @@ export function authRoutes(fastify: FastifyInstance) {
         }
 
         const protocol =
-          request.protocol ||
           (request.headers["x-forwarded-proto"] as string) ||
+          request.protocol ||
           "http";
-        const host = request.headers.host;
+        const host =
+          (request.headers["x-forwarded-host"] as string) ||
+          request.headers.host;
         const currentUrl = new URL(request.url, `${protocol}://${host}`);
 
         const state = currentUrl.searchParams.get("state");
@@ -661,9 +663,16 @@ export function authRoutes(fastify: FastifyInstance) {
           return reply.status(400).send("Invalid or expired session");
         }
 
+        // openid-client infers redirect_uri from the URL passed to authorizationCodeGrant.
+        // currentUrl is the API callback URL, but the IdP has the client-facing
+        // redirectUri registered. We must pass a URL with that path but keep the
+        // code/state query params so the token exchange succeeds.
+        const redirectUrl = new URL(oidc.redirectUri);
+        redirectUrl.search = currentUrl.search;
+
         let tokens = await oidcClient.authorizationCodeGrant(
           oidcConfig,
-          currentUrl,
+          redirectUrl,
           {
             pkceCodeVerifier: codeVerifier,
             expectedState: state,
@@ -677,11 +686,12 @@ export function authRoutes(fastify: FastifyInstance) {
           return reply.status(400).send("Missing access token");
         }
 
-        // Retrieve user information
+        // Retrieve user information — validate subject if claims are available
+        const claims = tokens.claims();
         const userInfo = await oidcClient.fetchUserInfo(
           oidcConfig,
           tokens.access_token,
-          oidcClient.skipSubjectCheck
+          claims?.sub ?? oidcClient.skipSubjectCheck
         );
 
         const userEmail = userInfo.email;
@@ -692,34 +702,32 @@ export function authRoutes(fastify: FastifyInstance) {
           });
         }
 
-        let user = await prisma.user.findUnique({
+        // Use upsert so concurrent logins don't cause a duplicate-key race condition.
+        // Existing users are left unchanged; new users are provisioned automatically.
+        const isNewUser = !(await prisma.user.findUnique({ where: { email: userEmail } }));
+
+        const user = await prisma.user.upsert({
           where: { email: userEmail },
+          update: {}, // existing users: no changes on login
+          create: {
+            email: userEmail,
+            password: await bcrypt.hash(generateRandomPassword(12), 10),
+            name: userInfo.name || userEmail.split("@")[0] || "New User",
+            isAdmin: false,
+            language: "en",
+            external_user: false,
+            firstLogin: true,
+          },
         });
 
-        await tracking("user_logged_in_oidc", {});
+        await tracking(isNewUser ? "user_created_oidc" : "user_logged_in_oidc", {});
 
-        if (!user) {
-          // Create a new basic user
-          user = await prisma.user.create({
-            data: {
-              email: userEmail,
-              password: await bcrypt.hash(generateRandomPassword(12), 10), // Set a random password of length 12
-              name: userInfo.name || "New User", // Use the name from userInfo or a default
-              isAdmin: false, // Set isAdmin to false for basic users
-              language: "en", // Set a default language
-              external_user: false, // Mark as external user
-              firstLogin: true, // Set firstLogin to true
-            },
-          });
-        }
-
-        var b64string = process.env.SECRET;
-        var secret = new Buffer(b64string!, "base64"); // Ta-da
+        const secret = Buffer.from(process.env.SECRET!, "base64");
 
         // Issue JWT token
         let signed_token = jwt.sign(
           {
-            data: { id: user.id },
+            data: { id: user.id, sessionId: crypto.randomBytes(32).toString("hex") },
           },
           secret,
           { expiresIn: "8h" }
@@ -731,6 +739,8 @@ export function authRoutes(fastify: FastifyInstance) {
             userId: user.id,
             sessionToken: signed_token,
             expires: new Date(Date.now() + 8 * 60 * 60 * 1000),
+            userAgent: request.headers["user-agent"] || "",
+            ipAddress: request.ip,
           },
         });
 
@@ -834,13 +844,12 @@ export function authRoutes(fastify: FastifyInstance) {
           });
         }
 
-        var b64string = process.env.SECRET;
-        var secret = new Buffer(b64string!, "base64"); // Ta-da
+        const secret = Buffer.from(process.env.SECRET!, "base64");
 
         // Issue JWT token
         let signed_token = jwt.sign(
           {
-            data: { id: user.id },
+            data: { id: user.id, sessionId: crypto.randomBytes(32).toString("hex") },
           },
           secret,
           { expiresIn: "8h" }
@@ -852,6 +861,8 @@ export function authRoutes(fastify: FastifyInstance) {
             userId: user.id,
             sessionToken: signed_token,
             expires: new Date(Date.now() + 8 * 60 * 60 * 1000),
+            userAgent: request.headers["user-agent"] || "",
+            ipAddress: request.ip,
           },
         });
 

--- a/apps/api/src/lib/jwt.ts
+++ b/apps/api/src/lib/jwt.ts
@@ -3,10 +3,9 @@ import jwt from "jsonwebtoken";
 export function checkToken(token: string) {
   const bearer = token;
 
-  var b64string = process.env.SECRET;
-  var buf = new Buffer(b64string!, "base64"); // Ta-da
+  const secret = Buffer.from(process.env.SECRET!, "base64");
 
-  const verified = jwt.verify(bearer, buf);
+  const verified = jwt.verify(bearer, secret);
 
   return verified;
 }

--- a/apps/api/src/lib/utils/oidc_client.ts
+++ b/apps/api/src/lib/utils/oidc_client.ts
@@ -1,14 +1,18 @@
 import * as client from "openid-client";
 
-let oidcConfig: client.Configuration | null = null;
+const configCache = new Map<string, client.Configuration>();
 
 export async function getOidcClient(config: any) {
-  if (!oidcConfig) {
-    oidcConfig = await client.discovery(new URL(config.issuer), config.clientId, {
-      redirect_uris: [config.redirectUri],
-      response_types: ["code"],
-      token_endpoint_auth_method: "none",
-    });
+  const cacheKey = `${config.issuer}|${config.clientId}|${config.redirectUri}`;
+  if (!configCache.has(cacheKey)) {
+    configCache.set(
+      cacheKey,
+      await client.discovery(new URL(config.issuer), config.clientId, {
+        redirect_uris: [config.redirectUri],
+        response_types: ["code"],
+        token_endpoint_auth_method: "none",
+      })
+    );
   }
-  return oidcConfig;
+  return configCache.get(cacheKey)!;
 }

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -30,6 +30,10 @@ const server: FastifyInstance = Fastify({
 });
 
 const publicRoutes = new Set([
+  "/api/v1/auth/check",
+  "/api/v1/auth/oidc/callback",
+  "/api/v1/auth/oauth/callback",
+  "/api/v1/auth/password-reset",
   "/",
   "/api/v1/auth/login",
   "/api/v1/auth/user/register/external",
@@ -52,11 +56,13 @@ function normalizeUrl(url: string) {
 }
 
 function isPublicRoute(url: string) {
-  const normalized = normalizeUrl(url);
+  const normalized = normalizeUrl(url.split("?")[0]);
   return (
     publicRoutes.has(normalized) ||
-    // Allow slight variations (trailing slashes, query strings) for known public endpoints
     normalized.startsWith("/api/v1/auth/user/register/external") ||
+    normalized.startsWith("/api/v1/auth/password-reset") ||
+    normalized.startsWith("/api/v1/auth/oidc/") ||
+    normalized.startsWith("/api/v1/auth/oauth/") ||
     normalized.startsWith("/docs/") ||
     normalized.startsWith("/api/v1/knowledge-base/public") ||
     normalized.startsWith("/api/v1/storage/public/")

--- a/apps/client/pages/auth/login.tsx
+++ b/apps/client/pages/auth/login.tsx
@@ -27,7 +27,6 @@ export default function Login({}) {
         .then((res) => res.json())
         .then(async (res) => {
           if (res.user) {
-            // Ensure cookie is sent to /api/* as well as /dashboard/*
             setCookie("session", res.token, { path: "/" });
             if (res.user.external_user) {
               router.push("/portal");
@@ -175,9 +174,9 @@ export default function Login({}) {
                 {url && (
                   <Button
                     type="submit"
-                    onClick={() => router.push(url)}
                     variant="outline"
                     className="w-full"
+                    onClick={() => { window.location.href = url; }}
                   >
                     Sign in with OIDC
                   </Button>
@@ -191,8 +190,8 @@ export default function Login({}) {
           <span className="font-bold text-foreground">
             Built with 💚 by Pepperminto Labs
           </span>
-          <a
-            href={process.env.KNOWLEDGE_BASE_URL ?? process.env.BASE_URL ?? "https://pepperminto.dev"}
+          
+          <a  href={process.env.KNOWLEDGE_BASE_URL ?? process.env.BASE_URL ?? "https://pepperminto.dev"}
             target="_blank"
             className="text-foreground"
           >

--- a/apps/client/pages/auth/oidc.tsx
+++ b/apps/client/pages/auth/oidc.tsx
@@ -6,16 +6,31 @@ export default function Login() {
   const router = useRouter();
 
   async function check() {
-    if (router.query.code) {
-      const sso = await fetch(
-        `/api/v1/auth/oidc/callback?state=${router.query.state}&code=${router.query.code}&session_state=${router.query.session_state}&iss=${router.query.iss}`
-      ).then((res) => res.json());
+    // Wait until Next.js has fully hydrated router.query from the URL.
+    // Without this, query params are empty on the first render and the
+    // callback fires with no code/state, producing a 400 from the API.
+    if (!router.isReady) return;
+    if (!router.query.code) return;
+
+    try {
+      const params = new URLSearchParams();
+      params.set("code", String(router.query.code));
+      params.set("state", String(router.query.state ?? ""));
+      // session_state and iss are optional — only forward if actually present
+      if (router.query.session_state) params.set("session_state", String(router.query.session_state));
+      if (router.query.iss) params.set("iss", String(router.query.iss));
+
+      const res = await fetch(`/api/v1/auth/oidc/callback?${params.toString()}`);
+      const sso = await res.json();
 
       if (!sso.success) {
-        router.push("/auth/login?error=account_not_found");
+        const errorParam = res.status >= 500 ? "oidc_error" : "account_not_found";
+        router.push(`/auth/login?error=${errorParam}`);
       } else {
         setandRedirect(sso.token, sso.onboarding);
       }
+    } catch {
+      router.push("/auth/login?error=oidc_error");
     }
   }
 
@@ -26,7 +41,7 @@ export default function Login() {
 
   useEffect(() => {
     check();
-  }, [router]);
+  }, [router.isReady, router.query]);
 
   return <div></div>;
 }


### PR DESCRIPTION
- Add /api/v1/auth/check, /api/v1/auth/oidc/callback, /api/v1/auth/oauth/callback and /api/v1/auth/password-reset to public routes in main.ts
- Fix isPublicRoute() to strip query strings before matching and add startsWith checks for all auth/oidc/, auth/oauth/ and auth/password-reset sub-paths
- Replace module-level OIDC client singleton with config-keyed Map cache in oidc_client.ts to prevent stale config after settings changes
- Fix authorizationCodeGrant() to use registered redirectUri from DB instead of inferring from the API callback URL, resolving redirect_uri mismatch errors
- Replace deprecated new Buffer() with Buffer.from() in auth.ts and jwt.ts
- Fix fetchUserInfo() to validate subject claim via claims?.sub with fallback to skipSubjectCheck instead of always skipping validation
- Add userAgent and ipAddress to OIDC and OAuth session creation to prevent immediate session invalidation by the hijacking check in checkSession()
- Add sessionId to JWT payload for OIDC and OAuth tokens matching password login
- Replace findUnique + create with upsert for OIDC user provisioning to handle concurrent login race conditions and auto-create missing users
- Fix login.tsx to use window.location.href instead of router.push() for OIDC redirect, preventing Next.js router from stripping state and PKCE query params
- Fix oidc.tsx to guard on router.isReady before reading query params, preventing premature callback execution before Next.js hydrates the URL
- Fix oidc.tsx to use URLSearchParams for callback URL construction, preventing undefined strings being forwarded for optional params
- Replace corepack prepare with npm install -g pnpm in Dockerfile.j to resolve build failures in environments without direct npmjs.org access